### PR TITLE
Fix typo in error message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## Unreleased - [0.3.1]
+
+### Bug fixes
+
+- Fix typo in error message.
+
 ## 2025-09-16 - [0.3.0]
 
 ### Breaking changes
@@ -149,6 +155,7 @@
 
 First beta release
 
+[0.3.1]: https://github.com/mondeja/hledger-fmt/compare/v0.3.0...master
 [0.3.0]: https://github.com/mondeja/hledger-fmt/compare/v0.2.11...v0.3.0
 [0.2.11]: https://github.com/mondeja/hledger-fmt/compare/v0.2.10...v0.2.11
 [0.2.10]: https://github.com/mondeja/hledger-fmt/compare/v0.2.9...v0.2.10

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -206,7 +206,7 @@ dependencies = [
 
 [[package]]
 name = "hledger-fmt"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anstream",
  "anstyle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hledger-fmt"
-version = "0.3.0"
+version = "0.3.1"
 rust-version = "1.74.1"
 edition = "2021"
 description = "An opinionated hledger's journal files formatter."

--- a/src/parser/errors.rs
+++ b/src/parser/errors.rs
@@ -13,7 +13,7 @@ pub struct SyntaxError {
 pub fn build_error_context(error: &SyntaxError, content: &str, file_path: &str) -> String {
     let lines = content.lines().collect::<Vec<&str>>();
     let mut context = format!(
-        "hlegder-fmt error: {}:{}:{}:\n",
+        "hledger-fmt error: {}:{}:{}:\n",
         file_path, error.lineno, error.colno_start
     );
 


### PR DESCRIPTION
`hlegder-fmt` -> `hledger-fmt`