### PR TITLE
fix(parser): preserve single-letter account names (#87)

### DIFF
--- a/src/formatter/tests.rs
+++ b/src/formatter/tests.rs
@@ -686,6 +686,17 @@ fn space_as_thousands_separator() {
     )
 }
 
+// https://github.com/mondeja/hledger-fmt/issues/87
+#[test]
+fn single_letter_account_names() {
+    assert_noop_format(
+        r"2026-01-01 Test
+    A  $-1
+    B   $1
+",
+    )
+}
+
 // Real-world corpus file tests
 // These tests verify that real-world journal files can be parsed and formatted correctly
 

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -746,10 +746,6 @@ fn parse_transaction_entry<'a>(line: &'a [u8], data: &mut ParserTempData<'a>) {
             } else {
                 entry_name_start = end - 1;
                 entry_name_end = entry_name_start;
-                // first non-whitespace byte resets the run, otherwise the
-                // trailing space of the indent would be treated as the
-                // second whitespace in the name/value separator and the
-                // entry name would saturate to empty (issue #87)
                 prev_was_whitespace = false;
                 break;
             }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -746,6 +746,11 @@ fn parse_transaction_entry<'a>(line: &'a [u8], data: &mut ParserTempData<'a>) {
             } else {
                 entry_name_start = end - 1;
                 entry_name_end = entry_name_start;
+                // first non-whitespace byte resets the run, otherwise the
+                // trailing space of the indent would be treated as the
+                // second whitespace in the name/value separator and the
+                // entry name would saturate to empty (issue #87)
+                prev_was_whitespace = false;
                 break;
             }
         }

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -770,20 +770,3 @@ fn regression_tab_indented_entries() {
     let result = parse_content(content.as_bytes());
     assert!(result.is_ok());
 }
-
-#[test]
-fn regression_single_letter_account_name_preserved() {
-    let content = "2026-01-01 Test\n    A  -$1\n    B  $1\n";
-    let journal = parse_content(content.as_bytes()).expect("parse must succeed");
-    let JournalCstNode::Transaction { entries, .. } = &journal[0] else {
-        panic!("expected Transaction, got {:?}", journal[0]);
-    };
-    let names: Vec<&str> = entries
-        .iter()
-        .filter_map(|n| match n {
-            TransactionNode::TransactionEntry(e) => Some(core::str::from_utf8(&e.name).unwrap()),
-            _ => None,
-        })
-        .collect();
-    assert_eq!(names, vec!["A", "B"], "single-letter names must round-trip");
-}

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -773,10 +773,6 @@ fn regression_tab_indented_entries() {
 
 #[test]
 fn regression_single_letter_account_name_preserved() {
-    // Single-letter account names must be preserved through the parser. Previously,
-    // `prev_was_whitespace` from the indent loop carried over into the name loop,
-    // so the first whitespace after a one-character account triggered the
-    // double-whitespace separator and the name was saturating-subtracted to empty.
     let content = "2026-01-01 Test\n    A  -$1\n    B  $1\n";
     let journal = parse_content(content.as_bytes()).expect("parse must succeed");
     let JournalCstNode::Transaction { entries, .. } = &journal[0] else {

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -770,3 +770,24 @@ fn regression_tab_indented_entries() {
     let result = parse_content(content.as_bytes());
     assert!(result.is_ok());
 }
+
+#[test]
+fn regression_single_letter_account_name_preserved() {
+    // Single-letter account names must be preserved through the parser. Previously,
+    // `prev_was_whitespace` from the indent loop carried over into the name loop,
+    // so the first whitespace after a one-character account triggered the
+    // double-whitespace separator and the name was saturating-subtracted to empty.
+    let content = "2026-01-01 Test\n    A  -$1\n    B  $1\n";
+    let journal = parse_content(content.as_bytes()).expect("parse must succeed");
+    let JournalCstNode::Transaction { entries, .. } = &journal[0] else {
+        panic!("expected Transaction, got {:?}", journal[0]);
+    };
+    let names: Vec<&str> = entries
+        .iter()
+        .filter_map(|n| match n {
+            TransactionNode::TransactionEntry(e) => Some(core::str::from_utf8(&e.name).unwrap()),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(names, vec!["A", "B"], "single-letter names must round-trip");
+}


### PR DESCRIPTION
Closes #87.

The indent loop in `parse_transaction_entry` kept `prev_was_whitespace=true` when it broke on the first non-whitespace byte, so the indent's trailing space counted as the first half of the name/value double-whitespace separator and `entry_name_end` saturating-subtracted below `entry_name_start`. Reset the flag at that branch (matching the second loop's behaviour). Regression test parses the issue's exact input and asserts both single-letter names round-trip.